### PR TITLE
Shopify: Fix make for some envs

### DIFF
--- a/shopify/base.makefile
+++ b/shopify/base.makefile
@@ -5,7 +5,7 @@ PROJECT_PATH=$(shell pwd)
 RIPTIDE_BIN=$(shell which riptide)
 RIPTIDE_SERVICE=shopify
 RIPTIDE_SOURCE=/src
-APP_NAME=$(shell printf '%s' "$${PWD##*/}")
+APP_NAME=$(shell basename $(CURDIR))
 DOCKER_IMAGE=riptidepy/shopify:latest
 DOCKER_USER=docker
 
@@ -93,8 +93,13 @@ define dev-container-run-cmd
 		-v ~/.npm:/home/$(DOCKER_USER)/.npm \
 		-v $(shell pwd):$(RIPTIDE_SOURCE) \
 		-w $(RIPTIDE_SOURCE) \
+		--env-file $(shell pwd)/.env \
 		$(DOCKER_IMAGE)
 endef
+
+app-dev: init-directories ## start dev app
+	$(dev-container-run-cmd) \
+		bash -c "./node_modules/.bin/shopify app dev" ||:
 
 init-app: init-directories ## initialize app
 	$(dev-container-run-cmd) \

--- a/shopify/entrypoint.sh
+++ b/shopify/entrypoint.sh
@@ -27,6 +27,9 @@ if [ -d "$RIPTIDE_SRC" ]; then
   if [ ! -f "$RIPTIDE_SRC""Makefile" ]; then
     cp /assets/Makefile "$RIPTIDE_SRC"
   fi
+  if [ ! -f "$RIPTIDE_SRC"".env" ]; then
+    touch "$RIPTIDE_SRC"".env"
+  fi
   cp /assets/shopify-app.md "$RIPTIDE_SRC"
 fi
 

--- a/shopify/shopify-app.md
+++ b/shopify/shopify-app.md
@@ -15,6 +15,8 @@ riptide setup
 riptide update
 ```
 
+Note: Make sure riptide is in your PATH (not just an alias to your bin), so it could be found with `which`.
+
 
 ## Create new app
 
@@ -67,6 +69,8 @@ If you have not installed the Riptide shell extensions, prepend `riptide cmd`.
 ```shell
 shopify app dev
 ```
+
+If this quits silently after "Dependencies installed", run `shopify auth logout`, `make init-app` and try again.
 
 
 ## Deploy extensions


### PR DESCRIPTION
In some envs the previous command to get the `APP_NAME` didn't worked.
In all Shopify repos we should have an `.env` file, containing further environment variables needed by the app.
The `shopify app dev` command has weird console output and is scrolling to the top instead of to the bottom, when new logs appear, when started with Riptide. So I added another docker command run with`make app-dev`.
Also added two notes to documentation.