### PR TITLE
Add modified Docker images for Keycloak

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,12 @@ jobs:
          - path: shopify
            tags:
              - riptidepy/shopify:latest
+         - path: keycloak/latest
+           tags:
+             - riptidepy/keycloak:latest
+         - path: keycloak/21.0.1
+           tags:
+             - riptidepy/keycloak:21.0.1
     name: Build Image
     steps:
       - name: Checkout

--- a/_contrib-templates/README.md
+++ b/_contrib-templates/README.md
@@ -13,22 +13,22 @@ Pay close attention to links and references with §§YOUR_IMAGE_NAME§§.
 
 <!--- Examples (and required formatting): --->
 
--	[`2.4.39`, `2.4`, `2`, `latest` (*2.4/Dockerfile*)](https://github.com/Parakoopa/riptide-docker-images/§§YOUR_IMAGE_NAME§§/2.4/Dockerfile)
--	[`2.4.39-alpine`, `2.4-alpine`, `2-alpine`, `alpine` (*2.4/alpine/Dockerfile*)](https://github.com/Parakoopa/riptide-docker-images/§§YOUR_IMAGE_NAME§§/2.4/alpine/Dockerfile)
+-	[`2.4.39`, `2.4`, `2`, `latest` (*2.4/Dockerfile*)](https://github.com/theCapypara/riptide-docker-images/§§YOUR_IMAGE_NAME§§/2.4/Dockerfile)
+-	[`2.4.39-alpine`, `2.4-alpine`, `2-alpine`, `alpine` (*2.4/alpine/Dockerfile*)](https://github.com/theCapypara/riptide-docker-images/§§YOUR_IMAGE_NAME§§/2.4/alpine/Dockerfile)
 
 # Quick reference
 
 -	**Where to get help**:
-	[the Riptide Docker Images Github Repository](https://github.com/Parakoopa/riptide-docker-images)
+	[the Riptide Docker Images Github Repository](https://github.com/theCapypara/riptide-docker-images)
 
 -	**Where to file issues**:
-	[https://github.com/Parakoopa/riptide-docker-images/issues](https://github.com/Parakoopa/riptide-docker-images/issues)
+	[https://github.com/theCapypara/riptide-docker-images/issues](https://github.com/theCapypara/riptide-docker-images/issues)
 
 -	**Maintained by**:
-	[the Riptide Community](https://github.com/Parakoopa/riptide-docker-images)
+	[the Riptide Community](https://github.com/theCapypara/riptide-docker-images)
 
 -	**Source of this description**:
-	[README in riptide-docker-images repo](https://github.com/Parakoopa/riptide-docker-images/tree/master/§§YOUR_IMAGE_NAME§§) ([history](https://github.com/Parakoopa/riptide-docker-images/tree/master/§§YOUR_IMAGE_NAME§§))
+	[README in riptide-docker-images repo](https://github.com/theCapypara/riptide-docker-images/tree/master/§§YOUR_IMAGE_NAME§§) ([history](https://github.com/theCapypara/riptide-docker-images/tree/master/§§YOUR_IMAGE_NAME§§))
 
 # What is §§YOUR_IMAGE_NAME§§?
 
@@ -38,7 +38,7 @@ Pay close attention to links and references with §§YOUR_IMAGE_NAME§§.
 
 <!-- General usage notes. After this, keep the following text: -->
 
-This image is meant to be used with [Riptide](https://github.com/Parakoopa/riptide-cli). 
+This image is meant to be used with [Riptide](https://github.com/theCapypara/riptide-cli). 
 Using it without Riptide is probably possible, but not supported.
 
 ## Basic Usage with Riptide

--- a/keycloak/21.0.1/Dockerfile
+++ b/keycloak/21.0.1/Dockerfile
@@ -29,4 +29,7 @@ RUN ln -s /usr/sbin/groupadd /usr/sbin/addgroup
 # Restore original /etc/group and /etc/passwd file
 COPY --from=keycloak /etc/passwd /etc/group /etc/
 
+# Allow keycloak to login
+RUN usermod -s /bin/bash keycloak
+
 USER keycloak

--- a/keycloak/21.0.1/Dockerfile
+++ b/keycloak/21.0.1/Dockerfile
@@ -3,6 +3,9 @@
 
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 
+# util-linux: provides /usr/bin/su
+# shadow-utils: provides /usr/sbin/groupadd
+# gawk: provides /usr/bin/awk
 ARG PACKAGES="util-linux shadow-utils gawk"
 
 RUN mkdir -p /mnt/rootfs

--- a/keycloak/21.0.1/Dockerfile
+++ b/keycloak/21.0.1/Dockerfile
@@ -1,0 +1,29 @@
+# Prepare additional packages for Keycloak
+# Source: https://www.keycloak.org/server/containers#_installing_additional_rpm_packages
+
+FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
+
+ARG PACKAGES="util-linux shadow-utils gawk"
+
+RUN mkdir -p /mnt/rootfs
+RUN dnf install --installroot /mnt/rootfs ${PACKAGES} --releasever 9 --setopt install_weak_deps=false --nodocs -y; dnf --installroot /mnt/rootfs clean all
+
+# Save original keycloak image as stage 
+
+FROM quay.io/keycloak/keycloak:21.0.1 AS keycloak
+
+# Modify keycloak image
+
+FROM keycloak
+
+COPY --from=ubi-micro-build /mnt/rootfs /
+
+USER root
+
+# Riptide tries to execute the debian-specific command addgroup
+RUN ln -s /usr/sbin/groupadd /usr/sbin/addgroup
+
+# Restore original /etc/group and /etc/passwd file
+COPY --from=keycloak /etc/passwd /etc/group /etc/
+
+USER keycloak

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,0 +1,57 @@
+# Supported tags and respective `Dockerfile` links
+
+-	[`21.0.1` (*21.0.1/Dockerfile*)](https://github.com/theCapypara/riptide-docker-images/keycloak/21.0.1/Dockerfile)
+-	[`latest` (*latest/Dockerfile*)](https://github.com/Parakoopa/riptide-docker-images/keycloak/latest/alpine/Dockerfile)
+
+# Quick reference
+
+-	**Where to get help**:
+	[the Riptide Docker Images Github Repository](https://github.com/theCapypara/riptide-docker-images)
+
+-	**Where to file issues**:
+	[https://github.com/theCapypara/riptide-docker-images/issues](https://github.com/theCapypara/riptide-docker-images/issues)
+
+-	**Maintained by**:
+	[the Riptide Community](https://github.com/theCapypara/riptide-docker-images)
+
+-	**Source of this description**:
+	[README in riptide-docker-images repo](https://github.com/theCapypara/riptide-docker-images/tree/master/keycloak) ([history](https://github.com/theCapypara/riptide-docker-images/tree/master/keycloak))
+
+# What is Keycloak?
+
+[Keycloak](https://keycloak.org) is an open source Identity and Access Management solution for modern applications and services.
+This image is modified from the [stock Keycloak image](https://quay.io/repository/keycloak/keycloak) to include a few required RPM packages for [Riptide](https://github.com/theCapypara/riptide-cli).
+
+# How to use this image.
+
+Refer to the [Keycloak documentation](https://www.keycloak.org/server/containers).
+
+This image is meant to be used with [Riptide](https://github.com/theCapypara/riptide-cli). 
+If you want to use it without Riptide you should consider using the official [Keycloak image](https://quay.io/repository/keycloak/keycloak) instead.
+Using this image without Riptide is probably possible, but not supported.
+
+## Basic Usage with Riptide
+
+For a service using this image, see: [Keycloak Riptide Service](https://github.com/theCapypara/riptide-repo/tree/master/service/keycloak)
+      
+The image is meant to be used only for services.
+
+This image supports ``run_as_current_user: true`` for services (this is the default).
+
+## Basic Usage with Docker Run
+
+Refer to the official documentation: [Running Keycloak in a container](https://www.keycloak.org/server/containers#_trying_keycloak_in_development_mode)
+
+# Environment Variables
+
+Keycloak can be configured using environment variables.
+For a complete list of configuration options, see: [Keycloak build options and configuration](https://www.keycloak.org/server/all-config)
+
+# Volumes
+
+These aren't required, but allow you to have a persist database and make further modifications.
+ 
+- **/opt/keycloak/conf**: Keycloak configuration files
+- **/opt/keycloak/data**: Database and cache related files
+- **/opt/keycloak/providers**: Additional dependencies for providers
+- **/opt/keycloak/themes**: Directory for custom themes

--- a/keycloak/latest/Dockerfile
+++ b/keycloak/latest/Dockerfile
@@ -29,4 +29,7 @@ RUN ln -s /usr/sbin/groupadd /usr/sbin/addgroup
 # Restore original /etc/group and /etc/passwd file
 COPY --from=keycloak /etc/passwd /etc/group /etc/
 
+# Allow keycloak to login
+RUN usermod -s /bin/bash keycloak
+
 USER keycloak

--- a/keycloak/latest/Dockerfile
+++ b/keycloak/latest/Dockerfile
@@ -1,0 +1,29 @@
+# Prepare additional packages for Keycloak
+# Source: https://www.keycloak.org/server/containers#_installing_additional_rpm_packages
+
+FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
+
+ARG PACKAGES="util-linux shadow-utils gawk"
+
+RUN mkdir -p /mnt/rootfs
+RUN dnf install --installroot /mnt/rootfs ${PACKAGES} --releasever 9 --setopt install_weak_deps=false --nodocs -y; dnf --installroot /mnt/rootfs clean all
+
+# Save original keycloak image as stage 
+
+FROM quay.io/keycloak/keycloak:latest AS keycloak
+
+# Modify keycloak image
+
+FROM keycloak
+
+COPY --from=ubi-micro-build /mnt/rootfs /
+
+USER root
+
+# Riptide tries to execute the debian-specific command addgroup
+RUN ln -s /usr/sbin/groupadd /usr/sbin/addgroup
+
+# Restore original /etc/group and /etc/passwd file
+COPY --from=keycloak /etc/passwd /etc/group /etc/
+
+USER keycloak

--- a/keycloak/latest/Dockerfile
+++ b/keycloak/latest/Dockerfile
@@ -3,6 +3,9 @@
 
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 
+# util-linux: provides /usr/bin/su
+# shadow-utils: provides /usr/sbin/groupadd
+# gawk: provides /usr/bin/awk
 ARG PACKAGES="util-linux shadow-utils gawk"
 
 RUN mkdir -p /mnt/rootfs


### PR DESCRIPTION
These images are required by https://github.com/theCapypara/riptide-repo/pull/31.

A few additional packages need to be installed, so riptide can execute the commands in `riptide-entrypoint.sh`.