### PR TITLE
Add xdg-utils for shopify images

### DIFF
--- a/shopify/builder/jinja_tpl/Dockerfile.jinja2
+++ b/shopify/builder/jinja_tpl/Dockerfile.jinja2
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     gcompat \
     icu \
     linux-headers \
-    freetype libjpeg-turbo libpng libwebp
+    freetype libjpeg-turbo libpng libwebp \
+    xdg-utils
 
 # add build dependencies
 RUN apk add --no-cache -t .build-deps \

--- a/shopify/n18.19.0/p8.1/Dockerfile
+++ b/shopify/n18.19.0/p8.1/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     gcompat \
     icu \
     linux-headers \
-    freetype libjpeg-turbo libpng libwebp
+    freetype libjpeg-turbo libpng libwebp \
+    xdg-utils
 
 # add build dependencies
 RUN apk add --no-cache -t .build-deps \

--- a/shopify/n18.19.0/p8.2/Dockerfile
+++ b/shopify/n18.19.0/p8.2/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     gcompat \
     icu \
     linux-headers \
-    freetype libjpeg-turbo libpng libwebp
+    freetype libjpeg-turbo libpng libwebp \
+    xdg-utils
 
 # add build dependencies
 RUN apk add --no-cache -t .build-deps \

--- a/shopify/n18.19.0/p8.3/Dockerfile
+++ b/shopify/n18.19.0/p8.3/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     gcompat \
     icu \
     linux-headers \
-    freetype libjpeg-turbo libpng libwebp
+    freetype libjpeg-turbo libpng libwebp \
+    xdg-utils
 
 # add build dependencies
 RUN apk add --no-cache -t .build-deps \

--- a/shopify/n20.11.0/p8.1/Dockerfile
+++ b/shopify/n20.11.0/p8.1/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     gcompat \
     icu \
     linux-headers \
-    freetype libjpeg-turbo libpng libwebp
+    freetype libjpeg-turbo libpng libwebp \
+    xdg-utils
 
 # add build dependencies
 RUN apk add --no-cache -t .build-deps \

--- a/shopify/n20.11.0/p8.2/Dockerfile
+++ b/shopify/n20.11.0/p8.2/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     gcompat \
     icu \
     linux-headers \
-    freetype libjpeg-turbo libpng libwebp
+    freetype libjpeg-turbo libpng libwebp \
+    xdg-utils
 
 # add build dependencies
 RUN apk add --no-cache -t .build-deps \

--- a/shopify/n20.11.0/p8.3/Dockerfile
+++ b/shopify/n20.11.0/p8.3/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     gcompat \
     icu \
     linux-headers \
-    freetype libjpeg-turbo libpng libwebp
+    freetype libjpeg-turbo libpng libwebp \
+    xdg-utils
 
 # add build dependencies
 RUN apk add --no-cache -t .build-deps \


### PR DESCRIPTION
This is needed for the Shopify login. Otherwise it will throw this error:
```
👉 Press any key to open the login page on your browser
Error: spawn xdg-open ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:476:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```
Now it says:
```
👉 Press any key to open the login page on your browser

Auto-open timed out. Open the login page: Log in to Shopify Partners ( http://accounts.shopify.com/oauth/authorize[...] )
```